### PR TITLE
Add refresh token classes

### DIFF
--- a/fastapi_users_db_sqlmodel/__init__.py
+++ b/fastapi_users_db_sqlmodel/__init__.py
@@ -8,7 +8,7 @@ from pydantic import UUID4, EmailStr, ConfigDict
 from pydantic.version import VERSION as PYDANTIC_VERSION
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
-from sqlmodel import Field, Session, SQLModel, func, select
+from sqlmodel import Field, Session, SQLModel, func, select, AutoString
 
 __version__ = "0.3.0"
 PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
@@ -21,7 +21,8 @@ class SQLModelBaseUserDB(SQLModel):
         email: str
     else:
         email: EmailStr = Field(
-            sa_column_kwargs={"unique": True, "index": True}, nullable=False
+            sa_column_kwargs={"unique": True, "index": True}, nullable=False,
+            sa_type=AutoString
         )
     hashed_password: str
 

--- a/fastapi_users_db_sqlmodel/__init__.py
+++ b/fastapi_users_db_sqlmodel/__init__.py
@@ -1,17 +1,19 @@
 """FastAPI Users database adapter for SQLModel."""
+
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Type
 
 from fastapi_users.db.base import BaseUserDatabase
 from fastapi_users.models import ID, OAP, UP
-from pydantic import UUID4, EmailStr, ConfigDict
+from pydantic import UUID4, ConfigDict, EmailStr
 from pydantic.version import VERSION as PYDANTIC_VERSION
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
-from sqlmodel import Field, Session, SQLModel, func, select, AutoString
+from sqlmodel import AutoString, Field, Session, SQLModel, func, select
 
 __version__ = "0.3.0"
 PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
+
 
 class SQLModelBaseUserDB(SQLModel):
     __tablename__ = "user"
@@ -21,8 +23,9 @@ class SQLModelBaseUserDB(SQLModel):
         email: str
     else:
         email: EmailStr = Field(
-            sa_column_kwargs={"unique": True, "index": True}, nullable=False,
-            sa_type=AutoString
+            sa_column_kwargs={"unique": True, "index": True},
+            nullable=False,
+            sa_type=AutoString,
         )
     hashed_password: str
 

--- a/fastapi_users_db_sqlmodel/access_token.py
+++ b/fastapi_users_db_sqlmodel/access_token.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Generic, Optional, Type
 from fastapi_users.authentication.strategy.db import AP, AccessTokenDatabase
 from pydantic import UUID4, ConfigDict
 from pydantic.version import VERSION as PYDANTIC_VERSION
-from sqlalchemy import Column, types
+from sqlalchemy import types
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import Field, Session, SQLModel, select
 
@@ -14,14 +14,12 @@ PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
 class SQLModelBaseAccessToken(SQLModel):
     __tablename__ = "accesstoken"
 
-    token: str = Field(
-        sa_column=Column("token", types.String(length=43), primary_key=True)
-    )
+    token: str = Field(sa_type=types.String(length=43), primary_key=True)
     created_at: datetime = Field(
         default_factory=now_utc,
-        sa_column=Column(
-            "created_at", TIMESTAMPAware(timezone=True), nullable=False, index=True
-        ),
+        sa_type=TIMESTAMPAware(timezone=True),
+        nullable=False,
+        index=True,
     )
     user_id: UUID4 = Field(foreign_key="user.id", nullable=False)
 

--- a/fastapi_users_db_sqlmodel/access_token.py
+++ b/fastapi_users_db_sqlmodel/access_token.py
@@ -1,7 +1,17 @@
 from datetime import datetime
 from typing import Any, Dict, Generic, Optional, Type
 
-from fastapi_users.authentication.strategy.db import AP, AccessTokenDatabase
+from fastapi_users.authentication.strategy.db import (
+    AP,
+    APE,
+    AccessRefreshTokenDatabase,
+    AccessTokenDatabase,
+)
+from fastapi_users.authentication.strategy.db.adapter import BaseAccessTokenDatabase
+from fastapi_users.authentication.strategy.db.models import (
+    AccessRefreshTokenProtocol,
+    AccessTokenProtocol,
+)
 from pydantic import UUID4, ConfigDict
 from pydantic.version import VERSION as PYDANTIC_VERSION
 from sqlalchemy import types
@@ -10,14 +20,23 @@ from sqlmodel import Field, Session, SQLModel, select
 
 from fastapi_users_db_sqlmodel.generics import TIMESTAMPAware, now_utc
 
-PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
-class SQLModelBaseAccessToken(SQLModel):
-    __tablename__ = "accesstoken"
+from . import SQLModelProtocolMetaclass
 
-    token: str = Field(sa_type=types.String(length=43), primary_key=True)
+PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
+
+
+class SQLModelBaseAccessToken(
+    SQLModel, AccessTokenProtocol, metaclass=SQLModelProtocolMetaclass
+):
+    __tablename__ = "accesstoken"  # type: ignore
+
+    token: str = Field(
+        sa_type=types.String(length=43),  # type: ignore
+        primary_key=True,
+    )
     created_at: datetime = Field(
         default_factory=now_utc,
-        sa_type=TIMESTAMPAware(timezone=True),
+        sa_type=TIMESTAMPAware(timezone=True),  # type: ignore
         nullable=False,
         index=True,
     )
@@ -26,11 +45,26 @@ class SQLModelBaseAccessToken(SQLModel):
     if PYDANTIC_V2:  # pragma: no cover
         model_config = ConfigDict(from_attributes=True)  # type: ignore
     else:  # pragma: no cover
+
         class Config:
             orm_mode = True
 
 
-class SQLModelAccessTokenDatabase(Generic[AP], AccessTokenDatabase[AP]):
+class SQLModelBaseAccessRefreshToken(
+    SQLModelBaseAccessToken,
+    AccessRefreshTokenProtocol,
+    metaclass=SQLModelProtocolMetaclass,
+):
+    __tablename__ = "accessrefreshtoken"
+
+    refresh_token: str = Field(
+        sa_type=types.String(length=43),  # type: ignore
+        unique=True,
+        index=True,
+    )
+
+
+class BaseSQLModelAccessTokenDatabase(Generic[AP], BaseAccessTokenDatabase[str, AP]):
     """
     Access token database adapter for SQLModel.
 
@@ -77,7 +111,47 @@ class SQLModelAccessTokenDatabase(Generic[AP], AccessTokenDatabase[AP]):
         self.session.commit()
 
 
-class SQLModelAccessTokenDatabaseAsync(Generic[AP], AccessTokenDatabase[AP]):
+class SQLModelAccessTokenDatabase(
+    Generic[AP], BaseSQLModelAccessTokenDatabase[AP], AccessTokenDatabase[AP]
+):
+    """
+    Access token database adapter for SQLModel.
+
+    :param session: SQLAlchemy session.
+    :param access_token_model: SQLModel access token model.
+    """
+
+
+class SQLModelAccessRefreshTokenDatabase(
+    Generic[APE], BaseSQLModelAccessTokenDatabase[APE], AccessRefreshTokenDatabase[APE]
+):
+    """
+    Access token database adapter for SQLModel.
+
+    :param session: SQLAlchemy session.
+    :param access_token_model: SQLModel access refresh token model.
+    """
+
+    async def get_by_refresh_token(
+        self, refresh_token: str, max_age: Optional[datetime] = None
+    ) -> Optional[APE]:
+        statement = select(self.access_token_model).where(  # type: ignore
+            self.access_token_model.refresh_token == refresh_token
+        )
+        if max_age is not None:
+            statement = statement.where(self.access_token_model.created_at >= max_age)
+
+        results = self.session.exec(statement)
+        access_token = results.first()
+        if access_token is None:
+            return None
+
+        return access_token
+
+
+class BaseSQLModelAccessTokenDatabaseAsync(
+    Generic[AP], BaseAccessTokenDatabase[str, AP]
+):
     """
     Access token database adapter for SQLModel working purely asynchronously.
 
@@ -122,3 +196,31 @@ class SQLModelAccessTokenDatabaseAsync(Generic[AP], AccessTokenDatabase[AP]):
     async def delete(self, access_token: AP) -> None:
         await self.session.delete(access_token)
         await self.session.commit()
+
+
+class SQLModelAccessTokenDatabaseAsync(
+    BaseSQLModelAccessTokenDatabaseAsync[AP], AccessTokenDatabase[AP], Generic[AP]
+):
+    pass
+
+
+class SQLModelAccessRefreshTokenDatabaseAsync(
+    BaseSQLModelAccessTokenDatabaseAsync[APE],
+    AccessRefreshTokenDatabase[APE],
+    Generic[APE],
+):
+    async def get_by_refresh_token(
+        self, refresh_token: str, max_age: Optional[datetime] = None
+    ) -> Optional[APE]:
+        statement = select(self.access_token_model).where(  # type: ignore
+            self.access_token_model.refresh_token == refresh_token
+        )
+        if max_age is not None:
+            statement = statement.where(self.access_token_model.created_at >= max_age)
+
+        results = await self.session.execute(statement)
+        access_token = results.first()
+        if access_token is None:
+            return None
+
+        return access_token[0]

--- a/fastapi_users_db_sqlmodel/generics.py
+++ b/fastapi_users_db_sqlmodel/generics.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Optional
 
 from sqlalchemy import TIMESTAMP, TypeDecorator
 
@@ -18,7 +19,8 @@ class TIMESTAMPAware(TypeDecorator):  # pragma: no cover
     impl = TIMESTAMP
     cache_ok = True
 
-    def process_result_value(self, value: datetime, dialect):
+    def process_result_value(self, value: Optional[datetime], dialect):
         if dialect.name != "postgresql":
-            return value.replace(tzinfo=timezone.utc)
+            if value is not None:
+                return value.replace(tzinfo=timezone.utc)
         return value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "fastapi-users >= 10.0.2",
+    "fastapi-users @ git+https://github.com/Ae-Mc/fastapi-users@add-refresh-token",
     "greenlet",
     "sqlmodel",
 ]


### PR DESCRIPTION
Add refresh token database classes that inherit base classes defined in fastapi-users in pull request #1367.
Add tests with 100% coverage.
Fix impossible to inherit models multiple times.
Fix models does not inherit base protocols.

TODO: replace fastapi-users dependency address in pyproject.toml after pull request approve in main repo.